### PR TITLE
無停止での更新作業ができるように

### DIFF
--- a/create-firewall-rules.rb
+++ b/create-firewall-rules.rb
@@ -1,11 +1,24 @@
 #! /usr/bin/env ruby
 
+require 'json'
+
+a_or_b = nil
+
+list_json = `gcloud compute firewall-rules list --format=json`
+hash = JSON.load(list_json)
+hash.each do |data|
+    a_or_b = "b" if data["name"].start_with?("block-cost-country-a-")
+    a_or_b = "a" if data["name"].start_with?("block-cost-country-b-")
+end
+
+a_or_b = "a" if a_or_b == nil
+
 ['cn', 'au'].each do |country|
     ips = File.open(country + '.txt').readlines.map{|v| v.chomp}
     cnt = 1
 
     ips.each_slice(254) do |ary|
-        name = 'block-cost-country-' + country + ('-%03d' % cnt)
+        name = 'block-cost-country-' + a_or_b + '-' + country + ('-%03d' % cnt)
 
         cmd_create = [
             'gcloud compute firewall-rules create',
@@ -22,4 +35,24 @@
         cnt += 1
     end
 
+    list_json = `gcloud compute firewall-rules list --format=json`
+    hash = JSON.load(list_json)
+    delete_names = []
+    hash.each do |data|
+        if (a_or_b == "a" && data["name"].start_with?("block-cost-country-b-")) ||
+            (a_or_b == "b" && data["name"].start_with?("block-cost-country-a-"))
+            delete_names.push(data["name"])
+        end
+    end
+
+    if delete_names != []
+        cmd_create = [
+            'gcloud compute firewall-rules delete',
+            delete_names.join(" "),
+            '--quiet',
+        ]
+        cmdstr_create = cmd_create.join(" ")
+        puts cmdstr_create
+        system cmdstr_create
+    end
 end


### PR DESCRIPTION
# 概要

2種類のフラグを元に更新作業を行うように修正

# 理由

ipアドレスと国の対応は一定ではなく、定期的に変更されます。

そのため、厳密に対応するためには定期的にIPアドレス帯の更新が必要です。

しかし現在のこのスクリプトでは1度きりしか実行できません。(2回目以降の実行時には同名のルールがすでに存在するためerror)
したがって、この状態でIPアドレス帯を更新するためには、一度CGPコンソールからルールの削除→IPアドレスを更新したスクリプトを再実行する必要がありますが、この削除→スクリプト再実行の間は「GCP でコストが高い国をブロックする」ためのFirewallのルールが存在しない状態になります。

そのため、現在のルールとは別名で作成→作成完了後旧ルールを削除するというフローが可能になるように、判定としてa,bというflagをルールに付与してそれを元に、更新・削除作業をするように変更しました。